### PR TITLE
Python 3 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ Installation
 Known issues
 -------------
 
-    * Does not work with Python 3.x, yet.
+    * Python 3.x support is experimental.
     * Unittests are not complete (see dev status)
 
 -------------

--- a/streak_client/__init__.py
+++ b/streak_client/__init__.py
@@ -1,3 +1,3 @@
 __version__ = '0.2.1'
-from streak_client import StreakClient
-from streak_objects import *
+from .streak_client import StreakClient
+from .streak_objects import *

--- a/streak_client/streak_client.py
+++ b/streak_client/streak_client.py
@@ -1,5 +1,5 @@
 import json, requests
-from streak_objects import *
+from .streak_objects import *
 
 import requests
 DEBUG = 0
@@ -55,7 +55,7 @@ class StreakClientBaseObject(object):
 						If not provided no data is sent
 			return 		code and req response dict (single or list)'''
 		if DEBUG:
-			print('uri', uri)
+			print(('uri', uri))
 
 		req_fp, content_type = self._get_req_fp(op)
 		
@@ -80,7 +80,7 @@ class StreakClientBaseObject(object):
 		return r.status_code, data
 	
 	def _form_encode(self, **kwargs):
-		out_string = '&'.join(str(k) + '=' + str(v) for k,v in kwargs.iteritems() if v is not None)
+		out_string = '&'.join(str(k) + '=' + str(v) for k,v in kwargs.items() if v is not None)
 		return out_string
 
 class StreakClient(StreakClientBaseObject):
@@ -132,7 +132,7 @@ class StreakClient(StreakClientBaseObject):
 		self.detail_level_suffix = '?detailLevel='
 
 		if DEBUG:
-			print(self.api_uri)
+			print((self.api_uri))
 
 	###
 	#Private Utility Methods
@@ -145,10 +145,10 @@ class StreakClient(StreakClientBaseObject):
 		'''
 		if DEBUG:
 			if req.status_code != requests.codes.ok:
-				print("code: {}".format(req.status_code))
-				print("response {}".format(req.json()))
-				print("req headers {}".format(req.request.headers))
-				print("req body {}".format(req.request.body))
+				print(("code: {}".format(req.status_code)))
+				print(("response {}".format(req.json())))
+				print(("req headers {}".format(req.request.headers)))
+				print(("req body {}".format(req.request.body)))
 
 	def _raise_unimplemented_error(self):
 		'''Exception helper for raising exceptions for unimplemented class members'''
@@ -472,7 +472,7 @@ class StreakClient(StreakClientBaseObject):
 		
 		#format is ambigious so we need to rely on user input
 		if stage_key:
-			data = data.values()
+			data = list(data.values())
 		
 		return code, data
 		

--- a/streak_client/streak_objects.py
+++ b/streak_client/streak_objects.py
@@ -42,7 +42,7 @@ class StreakBaseObject(object):
 		Args:
 			rw 			if True only returns the read/write enabled object attributes
 		'''
-		return {k:v for (k,v) in self.attributes.iteritems() 
+		return {k:v for (k,v) in self.attributes.items() 
 				if (v is not None and (not rw or (k in self.rw_attr_keys)))}
 class StreakUser(StreakBaseObject):
 	disp_attr_keys =	[

--- a/streak_client_tests/streak_client_tests.py
+++ b/streak_client_tests/streak_client_tests.py
@@ -91,7 +91,7 @@ class StreakClientPipelineAPITest(StreakClientTestBase):
 		self.assertEqual(len(data), 0, "Expected: 0, Read: {}".format(len(data)))
 	def test_get_delete_all_pipelines(self):
 		num_pl = 10
-		for i in xrange(num_pl):
+		for i in range(num_pl):
 			code, data = self.client.create_pipeline('my_name' + str(i), 'my_description' + str(i))
 			self.assertEqual(code, 200, "Create response is not OK. Code: {}".format(code))
 			self.assertTrue('name' in data and data['name'] == 'my_name' + str(i), 


### PR DESCRIPTION
I ran 2to3-3.4 on the codebase and it seems to have enabled python3 support.

Result from running `python -m streak_client_tests.streak_client_tests` are

```
test_create_update_get_delete_one_pipeline (__main__.StreakClientPipelineAPITest) ... ok
test_delete_all_pipelines (__main__.StreakClientPipelineAPITest) ... ok
test_get_delete_all_pipelines (__main__.StreakClientPipelineAPITest) ... ok
test_get_user_by_key (__main__.StreakClientUserAPITest) ... ok
test_get_user_by_key_invalid_key (__main__.StreakClientUserAPITest) ... ok
test_get_user_me (__main__.StreakClientUserAPITest) ... ok

----------------------------------------------------------------------
Ran 6 tests in 31.045s

OK
```
